### PR TITLE
Expose the droppableActiveId as meta property in onUpdate event

### DIFF
--- a/src/DndProvider.tsx
+++ b/src/DndProvider.tsx
@@ -52,7 +52,7 @@ export type DndProviderProps = {
   ) => void;
   onUpdate?: (
     event: GestureUpdateEvent<PanGestureHandlerEventPayload>,
-    meta: { activeId: UniqueIdentifier; activeLayout: LayoutRectangle },
+    meta: { activeId: UniqueIdentifier; activeLayout: LayoutRectangle; droppableActiveId: UniqueIdentifier },
   ) => void;
   onFinalize?: (
     event: GestureStateChangeEvent<PanGestureHandlerEventPayload>,
@@ -308,7 +308,7 @@ export const DndProvider = forwardRef<DndProviderHandle, PropsWithChildren<DndPr
           });
           droppableActiveId.value = findDroppableLayoutId(draggableActiveLayout.value);
           if (onUpdate) {
-            onUpdate(event, { activeId, activeLayout: draggableActiveLayout.value });
+            onUpdate(event, { activeId, activeLayout: draggableActiveLayout.value, droppableActiveId: droppableActiveId.value });
           }
         })
         .onFinalize((event) => {


### PR DESCRIPTION
Hello Olivier,

First of all, thank you for the wonderful contribution that is react-native-dnd.

I needed to access the active droppable Id during drag operations, ideally from the `dndPovider`. 
The `onDragEnd` event provides us with this at the end of the drag process, but I could not find a way to get the id before.  The reason was to manipulate some data unrelated to styling the components (which is already easily doable with `useAnimatedStyle`).

 I struggled with a few approaches trying to get it from within my droppable component using `useActiveDropReaction` and `useLatestValue` (and even 'hacking' the `useAnimatedStyle`) in combination with `runOnJs`. But they all proved too heavy and costly. Turning to the `dndPovider` and exposing the id that was already there seemed the cleanest way to go. 
 
It seems to me this could potentiality be a desired feature for many drag and drop type use cases and implementations. 
Please let me know if I missed something.

Thanks,
Kostas