### PR TITLE
allow simultaneous handlers (e.g for ScrollViews)

### DIFF
--- a/src/DndProvider.tsx
+++ b/src/DndProvider.tsx
@@ -60,6 +60,7 @@ export type DndProviderProps = {
   ) => void;
   hapticFeedback?: HapticFeedbackTypes;
   style?: StyleProp<ViewStyle>;
+  simultaneousHandlers?: React.Ref<any> | React.Ref<any>[];
   debug?: boolean;
 };
 
@@ -82,6 +83,7 @@ export const DndProvider = forwardRef<DndProviderHandle, PropsWithChildren<DndPr
       onUpdate,
       onFinalize,
       style,
+      simultaneousHandlers,
       debug,
     },
     ref,
@@ -402,7 +404,7 @@ export const DndProvider = forwardRef<DndProviderHandle, PropsWithChildren<DndPr
 
     return (
       <DndContext.Provider value={contextValue.current}>
-        <GestureDetector gesture={panGesture}>
+        <GestureDetector gesture={panGesture} simultaneousHandlers={simultaneousHandlers}>
           <View ref={containerRef} collapsable={false} style={style} testID="view">
             {children}
           </View>


### PR DESCRIPTION
Merci de partager ton travail Olivier !

I had the same issue as some other users: https://github.com/mgcrea/react-native-dnd/issues/17

I believe this solves the problem of the DndProvider blocking the scrolling behaviour of a ScrollView containing the DndProvider. 

Maybe the simultaneous scrolling should only be enabled if activationDelay > 100 (or something)?