### PR TITLE
fix(dndProvider): prevent app crash on unmount

### DIFF
--- a/src/DndProvider.tsx
+++ b/src/DndProvider.tsx
@@ -373,7 +373,9 @@ export const DndProvider = forwardRef<DndProviderHandle, PropsWithChildren<DndPr
               ) {
                 return;
               }
-              states[activeId].value = "resting";
+              if (states[activeId]) {
+                states[activeId].value = "resting";
+              }
               if (!finishedX || !finishedY) {
                 // console.log(`${activeId} did not finish to reach ${targetX.toFixed(2)} ${currentX}`);
               }


### PR DESCRIPTION
When the component is unmounted and an animation is still in progress the app crashes

Fixes #24 

![Screenshot_1718555564](https://github.com/mgcrea/react-native-dnd/assets/14938386/1ae19224-251c-455c-88f4-a100a86c50d9)
