### PR TITLE
Feature/draggable flatlist

### DIFF
--- a/docs/src/content/docs/providers/DndProvider.mdx
+++ b/docs/src/content/docs/providers/DndProvider.mdx
@@ -40,6 +40,9 @@ export const App: FunctionComponent = () => {
   <Property name="disabled" type="boolean" optional defaultValue={`false`}>
     An optional boolean value to disable the Drag and Drop functionality globally. Default is `false`.
   </Property>
+  <Property name="touchAction" type="TouchAction" optional>
+    An optional CSS touch-action value to pass to the GestureDetector for handling ScrollView interactions on web.
+  </Property>
   <Property name="onActivation" type="function" optional>
     A callback function that is called when a draggable item becomes active. Can be used to trigger haptic
     feedback.

--- a/src/DndContext.ts
+++ b/src/DndContext.ts
@@ -29,6 +29,7 @@ export type DndContextValue = {
   draggableActiveLayout: SharedValue<LayoutRectangle | null>;
   draggableInitialOffset: SharedPoint;
   draggableContentOffset: SharedPoint;
+  scrollOffset: SharedPoint;
   panGestureState: SharedValue<GestureEventPayload["state"]>;
 };
 

--- a/src/DndProvider.tsx
+++ b/src/DndProvider.tsx
@@ -11,6 +11,7 @@ import {
   PanGestureHandlerEventPayload,
   State,
 } from "react-native-gesture-handler";
+import type { TouchAction } from "react-native-gesture-handler/lib/typescript/handlers/gestureHandlerCommon";
 import {
   cancelAnimation,
   runOnJS,
@@ -46,6 +47,7 @@ export type DndProviderProps = {
   activationDelay?: number;
   minDistance?: number;
   disabled?: boolean;
+  touchAction?: TouchAction;
   onDragEnd?: (ev: { active: ItemOptions; over: ItemOptions | null }) => void;
   onBegin?: (
     event: GestureStateChangeEvent<PanGestureHandlerEventPayload>,
@@ -82,6 +84,7 @@ export const DndProvider = forwardRef<DndProviderHandle, PropsWithChildren<DndPr
       minDistance = 0,
       activationDelay = 0,
       disabled,
+      touchAction,
       onActivation,
       onDragEnd,
       onBegin,
@@ -411,7 +414,7 @@ export const DndProvider = forwardRef<DndProviderHandle, PropsWithChildren<DndPr
 
     return (
       <DndContext.Provider value={contextValue.current}>
-        <GestureDetector gesture={panGesture}>
+        <GestureDetector gesture={panGesture} touchAction={touchAction}>
           <View ref={containerRef} collapsable={false} style={style} testID="view">
             {children}
           </View>

--- a/src/DndProvider.tsx
+++ b/src/DndProvider.tsx
@@ -110,6 +110,7 @@ export const DndProvider = forwardRef<DndProviderHandle, PropsWithChildren<DndPr
     const draggableActiveLayout = useSharedValue<Rectangle | null>(null);
     const draggableInitialOffset = useSharedPoint(0, 0);
     const draggableContentOffset = useSharedPoint(0, 0);
+    const scrollOffset = useSharedPoint(0, 0);
     const panGestureState = useSharedValue<GestureEventPayload["state"]>(0);
 
     const contextValue = useRef<DndContextValue>({
@@ -128,6 +129,7 @@ export const DndProvider = forwardRef<DndProviderHandle, PropsWithChildren<DndPr
       draggableInitialOffset,
       draggableActiveLayout,
       draggableContentOffset,
+      scrollOffset,
     });
 
     useImperativeHandle(
@@ -171,8 +173,8 @@ export const DndProvider = forwardRef<DndProviderHandle, PropsWithChildren<DndPr
           if (
             !isDisabled &&
             includesPoint(layout.value, {
-              x: x - offset.x.value + draggableContentOffset.x.value,
-              y: y - offset.y.value + draggableContentOffset.y.value,
+              x: x - offset.x.value + draggableContentOffset.x.value + scrollOffset.x.value,
+              y: y - offset.y.value + draggableContentOffset.y.value + scrollOffset.y.value,
             })
           ) {
             return id;

--- a/src/features/sort/components/DraggableFlatList.tsx
+++ b/src/features/sort/components/DraggableFlatList.tsx
@@ -1,0 +1,98 @@
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  type ComponentPropsWithoutRef,
+} from "react";
+import { type FlexStyle, type ViewProps } from "react-native";
+import { FlatList } from "react-native-gesture-handler";
+import { runOnUI } from "react-native-reanimated";
+import { View } from "react-native-reanimated/lib/typescript/Animated";
+import { useDraggableStack, type UseDraggableStackOptions } from "../hooks/useDraggableStack";
+
+export type DraggableFlatListProps = Pick<ViewProps, "style"> &
+  Pick<UseDraggableStackOptions, "onOrderChange" | "onOrderUpdate" | "shouldSwapWorklet"> & {
+    direction?: FlexStyle["flexDirection"];
+    gap?: number;
+    data: ArrayLike<unknown>;
+    keyExtractor: (item: unknown, index: number) => string;
+  } & Omit<
+    ComponentPropsWithoutRef<typeof FlatList>,
+    "onScroll" | "ItemSeparatorComponent" | "data" | "keyExtractor"
+  >;
+
+export type DraggableFlatListHandle = Pick<ReturnType<typeof useDraggableStack>, "refreshOffsets">;
+
+export const DraggableFlatList = forwardRef<DraggableFlatListHandle, DraggableFlatListProps>(
+  function DraggableFlatList(
+    {
+      data,
+      keyExtractor,
+      direction = "row",
+      gap = 0,
+      onOrderChange,
+      onOrderUpdate,
+      shouldSwapWorklet,
+      style: styleProp,
+      ...props
+    },
+    ref,
+  ) {
+    const childrenIds = useMemo(() => {
+      const ids = Array.from(data).map((value, index) => keyExtractor(value, index));
+
+      return ids ? ids.filter(Boolean) : [];
+    }, [data]);
+
+    const style = useMemo(
+      () =>
+        Object.assign(
+          {
+            flexDirection: direction,
+            gap,
+          },
+          styleProp,
+        ),
+      [gap, direction, styleProp],
+    );
+
+    const horizontal = ["row", "row-reverse"].includes(style.flexDirection);
+
+    const { refreshOffsets, resetSortOrder, scrollOffset } = useDraggableStack({
+      gap: style.gap,
+      horizontal,
+      childrenIds,
+      onOrderChange,
+      onOrderUpdate,
+      shouldSwapWorklet,
+    });
+
+    useImperativeHandle(ref, () => {
+      return {
+        refreshOffsets,
+        resetSortOrder,
+      };
+    }, [refreshOffsets, resetSortOrder]);
+
+    useEffect(() => {
+      // Refresh offsets when children change
+      runOnUI(refreshOffsets)();
+    }, [childrenIds, refreshOffsets]);
+
+    return (
+      <FlatList
+        data={data}
+        keyExtractor={keyExtractor}
+        ItemSeparatorComponent={() => {
+          return <View style={{ height: gap }}></View>;
+        }}
+        onScroll={(event) => {
+          scrollOffset.x.value = event.nativeEvent.contentOffset.x;
+          scrollOffset.y.value = event.nativeEvent.contentOffset.y;
+        }}
+        {...props}
+      />
+    );
+  },
+);

--- a/src/features/sort/hooks/useDraggableStack.ts
+++ b/src/features/sort/hooks/useDraggableStack.ts
@@ -20,8 +20,14 @@ export const useDraggableStack = ({
   horizontal = false,
   shouldSwapWorklet = doesOverlapOnAxis,
 }: UseDraggableStackOptions) => {
-  const { draggableStates, draggableActiveId, draggableOffsets, draggableRestingOffsets, draggableLayouts } =
-    useDndContext();
+  const {
+    draggableStates,
+    draggableActiveId,
+    draggableOffsets,
+    draggableRestingOffsets,
+    draggableLayouts,
+    scrollOffset,
+  } = useDndContext();
   const axis = horizontal ? "x" : "y";
   const size = horizontal ? "width" : "height";
 
@@ -194,5 +200,5 @@ export const useDraggableStack = ({
     [horizontal],
   );
 
-  return { draggablePlaceholderIndex, draggableSortOrder, resetSortOrder, refreshOffsets };
+  return { draggablePlaceholderIndex, draggableSortOrder, resetSortOrder, refreshOffsets, scrollOffset };
 };

--- a/src/features/sort/hooks/useDraggableStack.ts
+++ b/src/features/sort/hooks/useDraggableStack.ts
@@ -27,6 +27,7 @@ export const useDraggableStack = ({
     draggableRestingOffsets,
     draggableLayouts,
     scrollOffset,
+    draggableActiveLayout
   } = useDndContext();
   const axis = horizontal ? "x" : "y";
   const size = horizontal ? "width" : "height";
@@ -200,5 +201,5 @@ export const useDraggableStack = ({
     [horizontal],
   );
 
-  return { draggablePlaceholderIndex, draggableSortOrder, resetSortOrder, refreshOffsets, scrollOffset };
+  return { draggablePlaceholderIndex, draggableSortOrder, resetSortOrder, refreshOffsets, scrollOffset,draggableActiveLayout };
 };


### PR DESCRIPTION
Hi @mgcrea  

I would appreciate your feedback on this feature. I'm trying to use the DraggableStack hook on a flatlist component, one of the issues I found was the [findActiveLayoutId function](https://github.com/mgcrea/react-native-dnd/blob/68152a94004e195412882b4d09d49666a1c809ff/src/DndProvider.tsx#L158) not being able to match the correct layout due to the gesture event position which doesn't account for scroll offset. 

After adding a scrollOffset to the DndProvider I have managed to reorder with the correct layout being found. Are there any other functions which would need to account for the scrollOffset such as draggableOffsets?